### PR TITLE
266: drop all records instead of collections

### DIFF
--- a/setup/drop.js
+++ b/setup/drop.js
@@ -6,7 +6,7 @@ const silent = process.argv.includes("--silent") || process.argv.includes("-s");
 
 silent ||
   process.stdout.write(
-    set("\n-------------------------------\n[-] DROPPING ALL COLLECTIONS...\n-------------------------------\n").blue
+    set("\n-------------------------------\n[-] DELETING ALL RECORDS FROM COLLECTIONS...\n-------------------------------\n").blue
   );
 
 const schemas = schemaData.map((data) => data.schema);
@@ -17,7 +17,7 @@ try {
   await Connection.close(silent);
   process.exit();
 } catch (error) {
-  silent && process.stdout.write(set(`[-] Error while dropping database: ${error} \n`).red);
+  silent && process.stdout.write(set(`[-] Error while deleting records: ${error} \n`).red);
   process.exit(1);
 }
 
@@ -29,14 +29,14 @@ try {
 async function dropIfExists(schemas) {
   for (const schema of schemas) {
     try {
-      await schema.collection.drop();
-      silent || process.stdout.write(`${set(`[-] DROP ${schema.collection.name}: `).blue}${set("SUCCESSFUL\n").green}`);
+      await schema.collection.deleteMany({});
+      silent || process.stdout.write(`${set(`[-] DELETING RECORDS FROM ${schema.collection.name}: `).blue}${set("SUCCESSFUL\n").green}`);
     } catch (error) {
       if (error.code === 26) {
         silent ||
-          process.stdout.write(`${set(`[-] DROP ${schema.collection.name}: `).blue}${set("DOES NOT EXIST\n").yellow}`);
+          process.stdout.write(`${set(`[-] DELETE RECORDS ${schema.collection.name}: `).blue}${set("DOES NOT EXIST\n").yellow}`);
       } else {
-        silent || process.stdout.write(`${set(`[-] DROP ${schema.collection.name}: `).blue}${set("FAILED\n").red}`);
+        silent || process.stdout.write(`${set(`[-] DELETE RECORDS ${schema.collection.name}: `).blue}${set("FAILED\n").red}`);
         throw new Error(error);
       }
     }


### PR DESCRIPTION
## Pull Request

### Brief Summary
- Refactored script "npm run drop" command to delete all records from collections without dropping the entire collection itself
- Note that deleteMany is used to delete all records from a collection instead of remove() since the latter is deprecated. 
- Source: https://www.mongodb.com/docs/manual/tutorial/remove-documents/

### Questions / Considerations for the Future
[comment]: <> (Note any questions, or things to note that might involve this PR in the future.)
- Should I be renaming the script as well? instead of drop, should it be renamed to empty/delete? 

### New Tests
- NA (manually tested using compass)

Closes #266 
