### PR TITLE
Implemented recursion in _removeExtraneousFields

### DIFF
--- a/app/controllers/photoTagController.js
+++ b/app/controllers/photoTagController.js
@@ -58,7 +58,6 @@ export default class PhotoTagController {
         throw new ErrorPhotoTagNotFound();
       }
     
-      Validate.outgoing(photoTag.creatingUser, userPublicResponse);
       Validate.outgoing(photoTag, photoTagResponse);
       res.status(200).json(photoTag);
     } catch (e) {

--- a/app/models/validationSchemas/photoTag.js
+++ b/app/models/validationSchemas/photoTag.js
@@ -1,5 +1,5 @@
 import { string, date, array, integer, object } from "./schemaTypes.js";
-import { UserPublicResponse } from "../apiModels/user.js";
+import { userPublicResponse } from "./user.js";
 
 /* photo tag response */
 export const photoTagResponse = {
@@ -8,7 +8,7 @@ export const photoTagResponse = {
   properties: {
     tagName: { type: string, unique: true, required: true },
     color: { type: string, required: true },
-    creatingUser: { type: UserPublicResponse.schema, required: true },
+    creatingUser: { type: userPublicResponse, required: true },
     creationTime: { type: date, required: true },
     modificationTime: { type: date, required: true },
   },

--- a/app/models/validationSchemas/validateSchema.js
+++ b/app/models/validationSchemas/validateSchema.js
@@ -65,15 +65,30 @@ export default class Validate {
 
   /**
    * Given an instance and a schema, this function will remove any fields from the
-   * instnace that are not defined in the schema.
+   * instance that are not defined in the schema.
    *
    * @param {JSON} instance instance of object being stripped
    * @param {JSON} schema json schema definition for object's validation
    * @returns
    */
   static _removeExtraneousFields(instance, schema) {
+    // Only process if schema is an object with defined properties
     if (schema.type !== "object" || !schema.properties) return;
-    for (const key in instance) if (!schema.properties[key]) delete instance[key];
+
+    for (const key in instance) {
+      // Remove field if key does not exist in schema
+      if (!schema.properties[key]) {
+        delete instance[key];
+        continue;
+      }
+
+      // Check if field is defined as nested object in schema
+      const nestedSchema = schema.properties[key].type;
+
+      if (nestedSchema.type) {
+        this._removeExtraneousFields(instance[key], nestedSchema);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Pull Request

[comment]: <> (Leave blank if a section does not apply.)
This branch is based off of #198 branch in order to use `phototag/name/:tagName` endpoint for testing

### Brief Summary
[comment]: <> (Put a brief summary of your changes.)
- Modified _removeExtraneousFields so it can work recursively for nested schemas

### Questions / Considerations for the Future
[comment]: <> (Note any questions, or things to note that might involve this PR in the future.)
- N/A

### API Changes
[comment]: <> (Note any new endpoints, deleted endpoints, or updated endpoints.)
- Updated getTagByName controller method used by `phototag/name/:tagName` endpoint for testing.  It uses a nested schema for the creatignUser, which was previously validated manually.  The creatingUser is now validated automatically with its parent schema, photoTag

### Database Changes
[comment]: <> (Note changes to any database schemas.)
- N/A

### New Tests
[comment]: <> (Note any new or modified test cases.)
- `phototag/name/:tagName` in branch #198 is used for testing since it uses nested schemas

[comment]: <> (Put the ticket # this PR closes.)
Closes #291 
