### PR TITLE
#201 Delete Photo Tag

### DIFF
--- a/app/controllers/photoTagController.js
+++ b/app/controllers/photoTagController.js
@@ -1,8 +1,6 @@
 import { PhotoTagCreate, PhotoTagResponse } from "../models/apiModels/photoTag.js";
 import PhotoTagAccessor from "../databaseAccessors/photoTagAccessor.js";
-import { ErrorTagNameNotFound, ErrorDuplicateKey, ErrorUnexpected, HttpError } from "../error/errors.js";
-import PhotoAccessor from "../databaseAccessors/photo.accessor.js";
-
+import { ErrorTagNameNotFound, ErrorDuplicateKey, ErrorUnexpected, HttpError } from "../error/errors.js"; 
 
 /**
  * PhotoTagController Class

--- a/app/controllers/photoTagController.js
+++ b/app/controllers/photoTagController.js
@@ -1,6 +1,7 @@
 import { PhotoTagCreate, PhotoTagResponse } from "../models/apiModels/photoTag.js";
 import PhotoTagAccessor from "../databaseAccessors/photoTagAccessor.js";
-import { ErrorDuplicateKey, ErrorUnexpected, HttpError } from "../error/errors.js";
+import { ErrorTagNameNotFound, ErrorDuplicateKey, ErrorUnexpected, HttpError } from "../error/errors.js";
+import PhotoAccessor from "../databaseAccessors/photo.accessor.js";
 
 
 /**
@@ -30,6 +31,34 @@ export default class PhotoTagController {
       const newTagResponse = new PhotoTagResponse(populatedNewTag.toObject());
       
       res.status(201).json(newTagResponse); 
+    } catch (e) {
+      if (e instanceof HttpError) {
+        e.throwHttp(req, res);
+      } else {
+        new ErrorUnexpected(e.message).throwHttp(req, res);
+      }
+    }
+  }
+
+/**
+ * Deletes a PhotoTag given the tagName within the url param
+ *
+ * @param {Request} req
+ * @param {Response} res
+ */
+  static async delete(req, res) {
+    try {
+
+      const tagName = req.params.tagName;
+      const tag = await PhotoTagAccessor.getTagByName(tagName);
+
+      if (!tag) { //if tag doesn't exist
+        throw new ErrorTagNameNotFound();
+      }
+      const deletedTag = await PhotoTagAccessor.deletePhotoTag(tag);
+      const deletedTagResponse = new PhotoTagResponse(deletedTag.toObject());
+      res.status(200).json(deletedTagResponse);
+
     } catch (e) {
       if (e instanceof HttpError) {
         e.throwHttp(req, res);

--- a/app/databaseAccessors/photo.accessor.js
+++ b/app/databaseAccessors/photo.accessor.js
@@ -1,4 +1,4 @@
-import Photo from "../models/photo.js";
+import Photo from "../models/dbModels/photo.js";
 import Connection from "../db/connection.js";
 import mongoose from "mongoose";
 

--- a/app/databaseAccessors/photoTagAccessor.js
+++ b/app/databaseAccessors/photoTagAccessor.js
@@ -1,6 +1,7 @@
 import PhotoTag from "../models/dbModels/photoTag.js";
 import Connection from "../db/connection.js";
 import mongoose from "mongoose";
+import Photo from "../models/dbModels/photo.js";
 
 /**
  * PhotoTag Accessor Class
@@ -18,6 +19,27 @@ export default class PhotoTagAccessor {
     await Connection.open();
     const createTag = await PhotoTag.create(tag);
     return createTag;
+  }
+
+  /**
+   * finds and deletes a photo tag with cascading effect
+   *
+   * @param {Object} tag - a PhotoTag object
+   * @return the deleted PhotoTag object
+   */
+  static async deletePhotoTag(tag) {
+    await Connection.open();
+
+    const deletedTag = await PhotoTag.findOneAndDelete(tag).populate("creatingUser");
+    const referencesToPhotoTag = [Photo];
+
+    for (const model of referencesToPhotoTag) {
+      await model.updateMany(
+        { tags: deletedTag._id }, 
+        { $pull: { tags: deletedTag._id } },
+      );
+    }
+    return deletedTag;
   }
 
   /**

--- a/app/error/errors.js
+++ b/app/error/errors.js
@@ -111,6 +111,12 @@ export class ErrorIssueMapNotFound extends HttpError {
   }
 }
 
+export class ErrorTagNameNotFound extends HttpError {
+  throwHttp(req, res) {
+    res.status(404).json({ error: "Photo Tag with the specified tag name is not found.", message: this.message });
+  }
+}
+
 export class ErrorInvalidRequestBody extends HttpError {
   throwHttp(req, res) {
     res.status(404).json({ error: "Invalid request body.", message: this.message });

--- a/app/models/apiModels/photo.js
+++ b/app/models/apiModels/photo.js
@@ -1,8 +1,8 @@
-import { BaseModel, string, date, object, now } from "./base_model.js";
-import Photography_status from "../enums/photography_status.js";
-import { ErrorInternalAPIModelValidation } from "../../error/internalErrors.js";
+import { BaseModel, string, date, object, now } from "./baseModel.js";
+//import Photography_status from "../enums/photography_status.js";
+//import { ErrorInternalAPIModelValidation } from "../../error/internalErrors.js";
 import { UserPublicResponse } from "./user.js";
-import { PhotoTagResponse } from "./photo_tags.js";
+import { PhotoTagResponse } from "./photoTag.js";
 
 /**
  * Represents the http request body required

--- a/app/routes/photoTagRoutes.js
+++ b/app/routes/photoTagRoutes.js
@@ -9,6 +9,6 @@ photoTag.route("/create").post(Authorize.allow([Accounts.Admin, Accounts.Photogr
 photoTag.route("/tag-name/:tagName"); //get a tag by its name
 photoTag.route("/filter"); //get photo tags by colors, creating users
 photoTag.route("/update/:tagName"); //update a photo tag
-photoTag.route("/delete/:tagName"); //delete a photo tag
+photoTag.route("/delete/:tagName").delete(Authorize.allow([Accounts.Admin, Accounts.Photographer]), PhotoTagController.delete); //delete a photo tag
 
 export default photoTag;

--- a/tests/__tests__/api/photoTag/deletePhotoTag.js
+++ b/tests/__tests__/api/photoTag/deletePhotoTag.js
@@ -43,6 +43,7 @@ describe("Delete PhotoTags Test", () => {
       .post("/photo-tag/create")
       .set("Cookie", [`token=${tokens["raisa@raisa.com"]}`])
       .send(validTag);
+    showLog && console.log(newTag.body);
     expect(newTag.statusCode).toBe(201);
   });
 

--- a/tests/__tests__/api/photoTag/deletePhotoTag.js
+++ b/tests/__tests__/api/photoTag/deletePhotoTag.js
@@ -1,0 +1,73 @@
+import request from "supertest";
+import app from "../../../../app/app.js";
+import tokens from "../../../testData/tokenTestData.js";
+import { log } from "../../../testConfig.js";
+import { executeReset, injectMockConnection, closeMockConnection } from "../../../util/util.js";
+import PhotoAccessor from "../../../../app/databaseAccessors/photo.accessor.js";
+
+const showLog = __filename
+  .replace(".js", "")
+  .split(/[/\\]/)
+  .splice(__filename.split(/[/\\]/).lastIndexOf("__tests__") + 1)
+  .reduce((acc, key) => acc && acc[key], log);
+beforeEach(injectMockConnection);
+beforeEach(executeReset);
+afterAll(closeMockConnection);
+
+describe("Delete PhotoTags Test", () => {
+  const validTag = {
+    tagName: "Clouds",
+    color: "#4CAF51",
+    creatingUser: "b00000000000000000000001",
+    creationTime: new Date("2024-04-06"),
+    modificationTime: new Date("2024-04-07"),
+  };
+
+  test("Tag deleted successfully", async () => {
+    const existingTag = await request(app)
+      .post("/photo-tag/create")
+      .set("Cookie", [`token=${tokens["raisa@raisa.com"]}`])
+      .send(validTag);
+    showLog && console.log(existingTag.body);
+    expect(existingTag.statusCode).toBe(201);
+
+    const deleteTag = await request(app)
+      .delete("/photo-tag/delete/Clouds")
+      .set("Cookie", [`token=${tokens["raisa@raisa.com"]}`]);
+    showLog && console.log(deleteTag.body);
+    expect(existingTag.body).toStrictEqual(deleteTag.body);
+    expect(deleteTag.statusCode).toBe(200);
+
+    //create same tag as before and should work without problem
+    const newTag = await request(app)
+      .post("/photo-tag/create")
+      .set("Cookie", [`token=${tokens["raisa@raisa.com"]}`])
+      .send(validTag);
+    expect(newTag.statusCode).toBe(201);
+  });
+
+  test("Deleting an invalid photoTag", async () => {
+    const deleteTag = await request(app)
+      .delete("/photo-tag/delete/Nonexistent")
+      .set("Cookie", [`token=${tokens["ethan@ethan.com"]}`]);
+    showLog && console.log(deleteTag.body);
+    expect(deleteTag.statusCode).toBe(404);
+  });
+
+  test("Deleting photoTag has cascading effects", async () => {
+    // 'Nature' tag exists in the database
+    const PhotosWithTag = await PhotoAccessor.getPhotosByTag("f00000000000000000000000");
+    PhotosWithTag.forEach(photo => {
+      // Check that the 'tags' array does not contain the deleted tag
+      expect((photo.tags).includes("f00000000000000000000000")).toBe(true);
+    });
+    const deleteTag = await request(app)
+      .delete("/photo-tag/delete/Nature")
+      .set("Cookie", [`token=${tokens["ethan@ethan.com"]}`]);
+    showLog && console.log(deleteTag.body);
+    // no photos with 'Nature' tag 
+    const currPhotosWithTag = await PhotoAccessor.getPhotosByTag(deleteTag._id);
+    expect(deleteTag.statusCode).toBe(200);
+    expect(currPhotosWithTag).toStrictEqual([]);
+    });
+});


### PR DESCRIPTION
## Pull Request

[comment]: <> (Leave blank if a section does not apply.)

### Brief Summary
[comment]: <> (Put a brief summary of your changes.)
-  Fixed the path for the photo model as it was causing issues.
- authorization of tag deletion is given to admin and photographers. 
- Included the cascading effect of photoTag deletion, but only to Photo at the moment (since it's the only model that references photoTag, but future models with references can be added to referencesToPhotoTag in photoTagAccessor.js
- provided 3 tests: 1 proper deletion, 1 improper deletion (tag does not exist), 1 proper deletion with cascading effect

### Questions / Considerations for the Future
[comment]: <> (Note any questions, or things to note that might involve this PR in the future.)
- 
- 

### API Changes
[comment]: <> (Note any new endpoints, deleted endpoints, or updated endpoints.)
- updated the endpoint photo-tag/delete/:tagName
- 

### Database Changes
[comment]: <> (Note changes to any database schemas.)
- 
- 

### New Tests
[comment]: <> (Note any new or modified test cases.)
- included new test for cascading deletion
- 

[comment]: <> (Put the ticket # this PR closes.)
Closes #201 
